### PR TITLE
Delete .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,0 @@
-include: 'https://gitlab.com/hackintosh5/ci-templates/-/raw/master/python-docker.gitlab-ci.yml'
-
-variables:
-    DOCKER_FLAGS: '-e TEST_BOT_TOKEN'


### PR DESCRIPTION
Остаток от оригинала с GitLab, тут он нахуй не нужен.