### PR TITLE
Fix no_nickname bug

### DIFF
--- a/friendly-telegram/dispatcher.py
+++ b/friendly-telegram/dispatcher.py
@@ -145,7 +145,7 @@ class CommandDispatcher:
 				elif tag[1].lower() != self._cached_username:
 					return
 			elif not self.no_nickname:
-				if event.is_private and not event.out:
+				if not event.is_private and not event.out:
 					return
 		logging.debug(tag[0])
 


### PR DESCRIPTION
In original dispatcher.py there is this "not", but in GTG there is no. This fixes stupid bug with calling commands without nickname even if no_nickname is set to False